### PR TITLE
feat(cli): add cobra CLI framework with build command

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"ha-syncgen/internal/config"
+
+	"github.com/spf13/cobra"
+)
+
+// buildCmd represents the build command
+var buildCmd = &cobra.Command{
+	Use:   "build [config file]",
+	Short: "Generate HA scripts and configuration from cluster.yaml",
+	Long: `Build reads your cluster.yaml configuration and generates all the necessary
+files for high-availability PostgreSQL setup including:
+- Sync scripts for each replica
+- Systemd service and timer units  
+- Health check and failover scripts
+- Optional observability configurations`,
+	Args:                  cobra.ExactArgs(1),
+	DisableFlagsInUseLine: true,
+
+	Run: func(cmd *cobra.Command, args []string) {
+
+		configFile := args[0]
+		cfg, err := config.Parse(configFile)
+		if err != nil {
+			fmt.Printf("Error parsing config file: %v\n", err)
+			return
+		}
+		config.Print(cfg)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(buildCmd)
+	// No flags configured for build command yet
+}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"ha-syncgen/internal/config"
+	"syncgen/internal/config"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,9 +23,9 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "ha-syncgen",
+	Use:   "syncgen",
 	Short: "PostgreSQL High Availability synchronization and failover automation tool",
-	Long: `ha-syncgen is a command-line tool for setting up and managing PostgreSQL high availability
+	Long: `syncgen is a command-line tool for setting up and managing PostgreSQL high availability
 configurations using file-level synchronization and automated failover mechanisms.
 
 The tool generates the necessary scripts, configuration files, and systemd services to

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,75 @@
+/*
+Copyright © 2025 ha-syncgen contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "ha-syncgen",
+	Short: "PostgreSQL High Availability synchronization and failover automation tool",
+	Long: `ha-syncgen is a command-line tool for setting up and managing PostgreSQL high availability
+configurations using file-level synchronization and automated failover mechanisms.
+
+The tool generates the necessary scripts, configuration files, and systemd services to
+establish a primary-replica PostgreSQL setup with:
+- Automated file synchronization using rsync over SSH
+- Real-time monitoring and health checks
+- Automatic failover to replica on primary failure
+- SSH key-based authentication for secure data transfer
+- Configurable sync intervals and retry policies
+
+Usage examples:
+  syncgen validate ha-config.yaml # Validate configuration
+  syncgen build [config file]               # Generate HA scripts and configuration
+  //  COMING SOON
+  syncgen status                           # Check current HA status
+  syncgen failover                         # Manual failover to replica
+
+For more information, visit: https://github.com/HasithDeAlwis/ha-syncgen`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	// Run: func(cmd *cobra.Command, args []string) { },
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	// Global configuration flags that apply to all subcommands
+	// These flags will be available across all ha-syncgen commands
+
+	// Config file flag - allows users to specify custom config location
+	// Default behavior will look for config in a standard location:
+	// 1. ./cluster.yaml (current directory)
+	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default searches standard locations)")
+
+	// Verbose output flag for debugging and detailed operation logs
+	// rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output for debugging")
+
+	// Dry-run flag to preview operations without making actual changes
+	// rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "preview operations without executing them")
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,71 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"ha-syncgen/internal/config"
+
+	"github.com/spf13/cobra"
+)
+
+// validateCmd represents the validate command
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate the configuration file without generating files",
+	Long: `The validate command checks the provided configuration file for correctness.
+	
+	Example usage:
+# cluster.yaml
+primary:
+  host: 10.0.0.1
+  port: 5432
+
+replicas:
+  - host: 10.0.0.2
+    sync_interval: 30s
+  - host: 10.0.0.3
+    sync_interval: 60s
+	syncgen validate cluster.yaml
+
+> syncgen validate cluster.yaml
+Build configuration:
+  Cluster Name: 10.0.0.1
+  Replica: 10.0.0.2 (Sync Interval: 30s)
+  Replica: 10.0.0.3 (Sync Interval: 60s)
+
+# cluster.yaml
+primary: 
+  port: 5432
+
+> syncgen validate cluster.yaml
+Error validating config file:
+Error: Primary host is required in the configuration file. Replicas are not provided.
+	`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		configFile := args[0]
+		cfg, err := config.Parse(configFile)
+		if err != nil {
+			fmt.Printf("%v\n", err)
+			return
+		}
+		fmt.Printf("Validation successful!")
+		config.Print(cfg)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// validateCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// validateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -5,7 +5,7 @@ package cmd
 
 import (
 	"fmt"
-	"ha-syncgen/internal/config"
+	"syncgen/internal/config"
 
 	"github.com/spf13/cobra"
 )

--- a/devenv/invalid.yaml
+++ b/devenv/invalid.yaml
@@ -1,0 +1,6 @@
+
+# Example cluster configuration for ha-syncgen
+# This file demonstrates how to configure a PostgreSQL HA cluster
+
+primary:
+  port: 5432

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,12 @@ module ha-syncgen
 
 go 1.23.3
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/spf13/cobra v1.9.1
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ha-syncgen
+module syncgen
 
 go 1.23.3
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,11 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ func Parse(filename string) (*Config, error) {
 	}
 
 	if err := Validate(&config); err != nil {
-		return nil, fmt.Errorf("validation error: %w", err)
+		return nil, fmt.Errorf("validation error:\n%w", err)
 	}
 
 	return &config, nil

--- a/internal/config/print.go
+++ b/internal/config/print.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"fmt"
+)
+
+func Print(cfg *Config) {
+	fmt.Printf("Build configuration:\n")
+	fmt.Printf("Primary Cluster Node: %s:%d\n", cfg.Primary.Host, cfg.Primary.Port)
+	if len(cfg.Replicas) == 0 {
+		fmt.Println("No replicas configured.")
+		return
+	}
+	for i, replica := range cfg.Replicas {
+		fmt.Printf("\tReplica %d: %s (Sync Interval: %s)\n", i+1, replica.Host, replica.SyncInterval)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "ha-syncgen/cmd"
+import "syncgen/cmd"
 
 func main() {
 	cmd.Execute()

--- a/main.go
+++ b/main.go
@@ -1,12 +1,7 @@
 package main
 
-import (
-	"fmt"
-	"os"
-)
+import "ha-syncgen/cmd"
 
 func main() {
-	fmt.Println("ha-syncgen v0.1.0")
-	fmt.Println("A declarative tool for scaffolding high-availability PostgreSQL infrastructure")
-	os.Exit(0)
+	cmd.Execute()
 }


### PR DESCRIPTION
## Checklist

- [x] My PR title matches issue title (type(scope): description)
- [x] I've tested it locally and nothing breaks
- [x] My code follows the project's coding and workflow standards
- [ ] If my change requires documentation updates, the documentation has been updated to reflect the new feature
- [ ] If my change closes an issue, I've linked the issue under the "Related Issues" section

---

## Summary

<!-- Describe your changes -->

## Related Issues

<!-- Link any Issue IDs (#) -->

## Additional Context

<!-- Add any other context or screenshots -->

## Summary by Sourcery

Introduce a Cobra-based CLI framework for ha-syncgen, replacing the simple main entrypoint with a root command and adding `validate` and `build` subcommands to parse and display cluster configurations.

New Features:
- Add a Cobra-based CLI with root command scaffolding
- Implement `validate` command to check configuration files without generation
- Implement `build` command to generate HA synchronization scripts and configuration

Enhancements:
- Replace main.go prints with cmd.Execute() to initialize the CLI
- Add config.Print function to display parsed cluster settings
- Update go.mod to include Cobra, pflag, and mousetrap dependencies
- Refine error message formatting in config validation

Chores:
- Add sample invalid.yaml file to the development environment