### PR TITLE
feat(cli): integrate generator with build command

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"syncgen/internal/config"
+	"syncgen/internal/generator"
 
 	"github.com/spf13/cobra"
 )
@@ -21,14 +23,38 @@ files for high-availability PostgreSQL setup including:
 	DisableFlagsInUseLine: true,
 
 	Run: func(cmd *cobra.Command, args []string) {
-
 		configFile := args[0]
 		cfg, err := config.Parse(configFile)
 		if err != nil {
 			fmt.Printf("Error parsing config file: %v\n", err)
 			return
 		}
+
+		// Print the configuration for user verification
+		fmt.Println("Configuration validated successfully:")
 		config.Print(cfg)
+
+		// Generate output directory
+		outputDir := "generated"
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			fmt.Printf("Error creating output directory: %v\n", err)
+			return
+		}
+
+		// Initialize generator and create all files
+		gen := generator.New(cfg, outputDir)
+		if err := gen.GenerateAll(); err != nil {
+			fmt.Printf("Error generating files: %v\n", err)
+			return
+		}
+
+		fmt.Printf("\n✅ HA PostgreSQL configuration generated successfully in '%s/' directory\n", outputDir)
+		fmt.Println("\nNext steps:")
+		fmt.Printf("1. Review the generated scripts in '%s/'\n", outputDir)
+		fmt.Println("2. Copy the scripts to your target servers")
+		fmt.Println("3. Set up PostgreSQL streaming replication by running the setup scripts")
+		fmt.Println("4. Install and enable the systemd services for automatic health monitoring")
+		fmt.Println("\nFor deployment help, run: syncgen --help")
 	},
 }
 


### PR DESCRIPTION
- Generate ha-postgres-health.service for health check execution
- Create ha-postgres-health.timer for scheduled monitoring (30sec intervals)
- Add proper systemd dependencies and security settings
- Support persistent timers across reboots with randomized delays
- Integrate with PostgreSQL service lifecycle management

Resolves #9

## Checklist

- [ ] My PR title matches issue title (type(scope): description)
- [ ] I've tested it locally and nothing breaks
- [ ] My code follows the project's coding and workflow standards
- [ ] If my change requires documentation updates, the documentation has been updated to reflect the new feature
- [ ] If my change closes an issue, I've linked the issue under the "Related Issues" section

---

## Summary

<!-- Describe your changes -->

## Related Issues

<!-- Link any Issue IDs (#) -->

## Additional Context

<!-- Add any other context or screenshots -->

## Summary by Sourcery

Extend configuration model with advanced streaming replication settings and integrate generator into the build command to produce setup scripts and systemd units.

New Features:
- Extend config model to include data directory, replication credentials, replication slots, sync modes, and streaming options
- Add validation with defaults for primary and replica settings and new fields like WAL level, wal keep size, and synchronous commit
- Introduce generator for primary and replica setup, producing postgresql.conf and pg_hba.conf patches, replication slot scripts, and streaming replication scripts
- Generate systemd service and timer units for scheduled health checks of PostgreSQL replication

Enhancements:
- Enhance CLI Print output to display detailed configuration summary with masked passwords
- Expand unit tests with extensive parsing, YAML tag mapping, and validation scenarios for all config fields