### PR TITLE
feat(datadog): create initalization scripts

### DIFF
--- a/internal/generator/datadog.go
+++ b/internal/generator/datadog.go
@@ -1,57 +1,51 @@
+
+
 package generator
 
 import (
-	"os"
 	"path/filepath"
 	"text/template"
 )
 
+
 func (g *Generator) generateDatadogFiles(installTmpl, sqlTmpl, confTmpl *template.Template) error {
-	ddDir := filepath.Join(g.outputDir, "datadog")
-	if err := os.MkdirAll(ddDir, 0755); err != nil {
-		return err
-	}
-	if err := g.generateDDInstallScript(installTmpl, ddDir); err != nil {
-		return err
-	}
-	if err := g.generateDDSQLFile(sqlTmpl, ddDir); err != nil {
-		return err
-	}
-	if err := g.generateDDConfigFile(confTmpl, ddDir); err != nil {
-		return err
-	}
-	return nil
-}
-
-// generateDDInstallScript creates the Datadog agent install script using a Go template
-func (g *Generator) generateDDInstallScript(installTmpl *template.Template, ddDir string) error {
-	data := map[string]interface{}{
-		"DataDogApiKey": g.config.Monitoring.Datadog.ApiKey,
-		"DataDogSite":   g.config.Monitoring.Datadog.Site,
-	}
-	outputFile := filepath.Join(ddDir, "datadog-install.sh")
-	return executeTemplateToFile(installTmpl, data, outputFile, "datadog-install.sh")
-}
-
-// generateDDSQLFile creates the SQL file for Datadog user setup using a Go template
-func (g *Generator) generateDDSQLFile(sqlTmpl *template.Template, ddDir string) error {
-	data := map[string]interface{}{
-		"Password": g.config.Primary.DbPassword,
-	}
-	outputFile := filepath.Join(ddDir, "datadog.sql")
-	return executeTemplateToFile(sqlTmpl, data, outputFile, "datadog.sql")
-}
-
-// generateDDConfigFile creates the Datadog agent config YAML using a Go template
-func (g *Generator) generateDDConfigFile(confTmpl *template.Template, ddDir string) error {
-	data := map[string]interface{}{
-		"Host":          g.config.Primary.Host,
-		"Port":          g.config.Primary.Port,
-		"DbName":        g.config.Primary.DbName,
-		"DbUser":        g.config.Primary.DbUser,
-		"DbPassword":    g.config.Primary.DbPassword,
-		"Datadirectory": g.config.Primary.DataDirectory,
-	}
-	outputFile := filepath.Join(ddDir, "datadog-conf.yaml")
-	return executeTemplateToFile(confTmpl, data, outputFile, "datadog-conf.yaml")
+   ddDir := filepath.Join(g.outputDir, "datadog")
+   specs := []FileSpec{
+	   {
+		   Tmpl:     installTmpl,
+		   Dir:      ddDir,
+		   Filename: "datadog-install.sh",
+		   Data: map[string]interface{}{
+			   "DataDogApiKey": g.config.Monitoring.Datadog.ApiKey,
+			   "DataDogSite":   g.config.Monitoring.Datadog.Site,
+		   },
+	   },
+	   {
+		   Tmpl:     sqlTmpl,
+		   Dir:      ddDir,
+		   Filename: "datadog.sql",
+		   Data: map[string]interface{}{
+			   "Password": g.config.Primary.DbPassword,
+		   },
+	   },
+	   {
+		   Tmpl:     confTmpl,
+		   Dir:      ddDir,
+		   Filename: "datadog-conf.yaml",
+		   Data: map[string]interface{}{
+			   "Host":          g.config.Primary.Host,
+			   "Port":          g.config.Primary.Port,
+			   "DbName":        g.config.Primary.DbName,
+			   "DbUser":        g.config.Primary.DbUser,
+			   "DbPassword":    g.config.Primary.DbPassword,
+			   "Datadirectory": g.config.Primary.DataDirectory,
+		   },
+	   },
+   }
+   for _, spec := range specs {
+	   if err := g.renderTemplate(spec.Tmpl, spec.Dir, spec.Filename, spec.Data); err != nil {
+		   return err
+	   }
+   }
+   return nil
 }

--- a/internal/generator/datadog.go
+++ b/internal/generator/datadog.go
@@ -10,11 +10,24 @@ func (g *Generator) generateDatadogFiles(installTmpl, sqlTmpl, confTmpl *templat
 	if err := os.MkdirAll(ddDir, 0755); err != nil {
 		return err
 	}
+	if err := g.generateDDInstallScript(installTmpl, ddDir); err != nil {
+		return err
+	}
 	if err := g.generateDDSQLFile(sqlTmpl, ddDir); err != nil {
 		return err
 	}
 	return nil
 }
+// generateDDInstallScript creates the Datadog agent install script using a Go template
+func (g *Generator) generateDDInstallScript(installTmpl *template.Template, ddDir string) error {
+	data := map[string]interface{}{
+		"DataDogApiKey": g.config.Monitoring.Datadog.ApiKey,
+		"DataDogSite":   g.config.Monitoring.Datadog.Site,
+	}
+	outputFile := filepath.Join(ddDir, "datadog-install.sh")
+	return executeTemplateToFile(installTmpl, data, outputFile, "datadog-install.sh")
+}
+
 // generateDDSQLFile creates the SQL file for Datadog user setup using a Go template
 func (g *Generator) generateDDSQLFile(sqlTmpl *template.Template, ddDir string) error {
 	data := map[string]interface{}{

--- a/internal/generator/datadog.go
+++ b/internal/generator/datadog.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"text/template"
 )
+
 func (g *Generator) generateDatadogFiles(installTmpl, sqlTmpl, confTmpl *template.Template) error {
 	ddDir := filepath.Join(g.outputDir, "datadog")
 	if err := os.MkdirAll(ddDir, 0755); err != nil {
@@ -16,8 +17,12 @@ func (g *Generator) generateDatadogFiles(installTmpl, sqlTmpl, confTmpl *templat
 	if err := g.generateDDSQLFile(sqlTmpl, ddDir); err != nil {
 		return err
 	}
+	if err := g.generateDDConfigFile(confTmpl, ddDir); err != nil {
+		return err
+	}
 	return nil
 }
+
 // generateDDInstallScript creates the Datadog agent install script using a Go template
 func (g *Generator) generateDDInstallScript(installTmpl *template.Template, ddDir string) error {
 	data := map[string]interface{}{
@@ -35,4 +40,18 @@ func (g *Generator) generateDDSQLFile(sqlTmpl *template.Template, ddDir string) 
 	}
 	outputFile := filepath.Join(ddDir, "datadog.sql")
 	return executeTemplateToFile(sqlTmpl, data, outputFile, "datadog.sql")
+}
+
+// generateDDConfigFile creates the Datadog agent config YAML using a Go template
+func (g *Generator) generateDDConfigFile(confTmpl *template.Template, ddDir string) error {
+	data := map[string]interface{}{
+		"Host":          g.config.Primary.Host,
+		"Port":          g.config.Primary.Port,
+		"DbName":        g.config.Primary.DbName,
+		"DbUser":        g.config.Primary.DbUser,
+		"DbPassword":    g.config.Primary.DbPassword,
+		"Datadirectory": g.config.Primary.DataDirectory,
+	}
+	outputFile := filepath.Join(ddDir, "datadog-conf.yaml")
+	return executeTemplateToFile(confTmpl, data, outputFile, "datadog-conf.yaml")
 }

--- a/internal/generator/datadog.go
+++ b/internal/generator/datadog.go
@@ -1,0 +1,25 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"text/template"
+)
+func (g *Generator) generateDatadogFiles(installTmpl, sqlTmpl, confTmpl *template.Template) error {
+	ddDir := filepath.Join(g.outputDir, "datadog")
+	if err := os.MkdirAll(ddDir, 0755); err != nil {
+		return err
+	}
+	if err := g.generateDDSQLFile(sqlTmpl, ddDir); err != nil {
+		return err
+	}
+	return nil
+}
+// generateDDSQLFile creates the SQL file for Datadog user setup using a Go template
+func (g *Generator) generateDDSQLFile(sqlTmpl *template.Template, ddDir string) error {
+	data := map[string]interface{}{
+		"Password": g.config.Primary.DbPassword,
+	}
+	outputFile := filepath.Join(ddDir, "datadog.sql")
+	return executeTemplateToFile(sqlTmpl, data, outputFile, "datadog.sql")
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -5,9 +5,26 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-
 	"syncgen/internal/config"
+	"text/template"
 )
+
+// FileSpec defines a file generation specification
+type FileSpec struct {
+	Tmpl     *template.Template
+	Dir      string
+	Filename string
+	Data     map[string]interface{}
+}
+
+// renderTemplate renders a template to a file in the given directory
+func (g *Generator) renderTemplate(tmpl *template.Template, dir, filename string, data map[string]interface{}) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	outputFile := filepath.Join(dir, filename)
+	return executeTemplateToFile(tmpl, data, outputFile, filename)
+}
 
 // Generator handles the generation of all configuration files
 type Generator struct {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -55,11 +55,22 @@ func (g *Generator) GenerateAll() error {
 		if err != nil {
 			return fmt.Errorf("failed to parse datadog-install.sh template: %w", err)
 		}
+
 		datadogSQLTmpl, err := parseTemplateByName(tmplDir, "datadog.sql.tmpl")
 		if err != nil {
 			return fmt.Errorf("failed to parse datadog.sql template: %w", err)
 		}
+
+		datadogConfTmpl, err := parseTemplateByName(tmplDir, "datadog-conf.yaml.tmpl")
+		if err != nil {
+			return fmt.Errorf("failed to parse datadog-conf.yaml template: %w", err)
+		}
+
+		if err := g.generateDatadogFiles(datadogInstallTmpl, datadogSQLTmpl, datadogConfTmpl); err != nil {
+			return fmt.Errorf("failed to generate Datadog files: %w", err)
+		}
 	}
+
 	// Generate replica-specific files
 	for _, replica := range g.config.Replicas {
 		if err := g.generateReplicaFiles(replica); err != nil {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -50,6 +50,16 @@ func (g *Generator) GenerateAll() error {
 		return fmt.Errorf("failed to generate primary files: %w", err)
 	}
 
+	if g.config.Monitoring.Datadog.Enabled {
+		datadogInstallTmpl, err := parseTemplateByName(tmplDir, "datadog-install.sh.tmpl")
+		if err != nil {
+			return fmt.Errorf("failed to parse datadog-install.sh template: %w", err)
+		}
+		datadogSQLTmpl, err := parseTemplateByName(tmplDir, "datadog.sql.tmpl")
+		if err != nil {
+			return fmt.Errorf("failed to parse datadog.sql template: %w", err)
+		}
+	}
 	// Generate replica-specific files
 	for _, replica := range g.config.Replicas {
 		if err := g.generateReplicaFiles(replica); err != nil {

--- a/internal/generator/primary.go
+++ b/internal/generator/primary.go
@@ -1,77 +1,60 @@
+
 package generator
 
 import (
-	"os"
 	"path/filepath"
 	"text/template"
 )
 
+
 // generatePrimaryFiles creates configuration files for the primary PostgreSQL server
 func (g *Generator) generatePrimaryFiles(pgHbaTmpl, postgresqlConfTmpl, setupPrimaryTmpl *template.Template) error {
-	primaryDir := filepath.Join(g.outputDir, "primary")
-	if err := os.MkdirAll(primaryDir, 0755); err != nil {
-		return err
-	}
-
-	// Generate PostgreSQL configuration patches
-	if err := g.generatePostgreSQLConfig(primaryDir, postgresqlConfTmpl); err != nil {
-		return err
-	}
-
-	// Generate pg_hba.conf patches for replication
-	if err := g.generatePgHbaConfig(primaryDir, pgHbaTmpl); err != nil {
-		return err
-	}
-
-	// Generate replication slot setup script
-	if err := g.generateReplicationSlotSetup(primaryDir, setupPrimaryTmpl); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// generatePostgreSQLConfig creates postgresql.conf patches for streaming replication
-
-func (g *Generator) generatePostgreSQLConfig(primaryDir string, postgresqlConfTmpl *template.Template) error {
-	data := map[string]interface{}{
-		"WalLevel":            g.config.Options.WalLevel,
-		"HotStandby":          g.config.Options.HotStandby,
-		"SynchronousCommit":   g.config.Options.SynchronousCommit,
-		"MaxWalSenders":       g.config.Options.MaxWalSenders,
-		"MaxReplicationSlots": len(g.config.Replicas) + 2,
-		"WalKeepSize":         g.config.Options.WalKeepSize,
-		"Port":                g.config.Primary.Port,
-		"HasMonitoring":       g.config.Monitoring.Datadog.Enabled,
-	}
-	outputFile := filepath.Join(primaryDir, "postgresql.conf.custom")
-	return executeTemplateToFile(postgresqlConfTmpl, data, outputFile, "postgres.conf")
-}
-
-// generatePgHbaConfig creates pg_hba.conf entries for replication using a Go template
-
-func (g *Generator) generatePgHbaConfig(primaryDir string, pgHbaTmpl *template.Template) error {
-	data := map[string]interface{}{
-		"ReplicationUser": g.config.Primary.ReplicationUser,
-		"Replicas":        g.config.Replicas,
-	}
-	outputFile := filepath.Join(primaryDir, "pg_hba.conf.custom")
-	return executeTemplateToFile(pgHbaTmpl, data, outputFile, "pg_hba.conf")
-}
-
-// generateReplicationSlotSetup creates a script to set up replication slots on the primary using a Go template
-
-func (g *Generator) generateReplicationSlotSetup(primaryDir string, setupPrimaryTmpl *template.Template) error {
-	data := map[string]interface{}{
-		"PrimaryHost":         g.config.Primary.Host,
-		"PrimaryPort":         g.config.Primary.Port,
-		"DbUser":              g.config.Primary.DbUser,
-		"DbName":              g.config.Primary.DbName,
-		"ReplicationUser":     g.config.Primary.ReplicationUser,
-		"ReplicationPassword": g.config.Primary.ReplicationPassword,
-		"Replicas":            g.config.Replicas,
-		"DataDirectory":       g.config.Primary.DataDirectory,
-	}
-	outputFile := filepath.Join(primaryDir, "setup_primary.sh")
-	return executeTemplateToFile(setupPrimaryTmpl, data, outputFile, "setup_primary.sh")
+   primaryDir := filepath.Join(g.outputDir, "primary")
+   specs := []FileSpec{
+	   {
+		   Tmpl:     postgresqlConfTmpl,
+		   Dir:      primaryDir,
+		   Filename: "postgresql.conf.custom",
+		   Data: map[string]interface{}{
+			   "WalLevel":            g.config.Options.WalLevel,
+			   "HotStandby":          g.config.Options.HotStandby,
+			   "SynchronousCommit":   g.config.Options.SynchronousCommit,
+			   "MaxWalSenders":       g.config.Options.MaxWalSenders,
+			   "MaxReplicationSlots": len(g.config.Replicas) + 2,
+			   "WalKeepSize":         g.config.Options.WalKeepSize,
+			   "Port":                g.config.Primary.Port,
+			   "HasMonitoring":       g.config.Monitoring.Datadog.Enabled,
+		   },
+	   },
+	   {
+		   Tmpl:     pgHbaTmpl,
+		   Dir:      primaryDir,
+		   Filename: "pg_hba.conf.custom",
+		   Data: map[string]interface{}{
+			   "ReplicationUser": g.config.Primary.ReplicationUser,
+			   "Replicas":        g.config.Replicas,
+		   },
+	   },
+	   {
+		   Tmpl:     setupPrimaryTmpl,
+		   Dir:      primaryDir,
+		   Filename: "setup_primary.sh",
+		   Data: map[string]interface{}{
+			   "PrimaryHost":         g.config.Primary.Host,
+			   "PrimaryPort":         g.config.Primary.Port,
+			   "DbUser":              g.config.Primary.DbUser,
+			   "DbName":              g.config.Primary.DbName,
+			   "ReplicationUser":     g.config.Primary.ReplicationUser,
+			   "ReplicationPassword": g.config.Primary.ReplicationPassword,
+			   "Replicas":            g.config.Replicas,
+			   "DataDirectory":       g.config.Primary.DataDirectory,
+		   },
+	   },
+   }
+   for _, spec := range specs {
+	   if err := g.renderTemplate(spec.Tmpl, spec.Dir, spec.Filename, spec.Data); err != nil {
+		   return err
+	   }
+   }
+   return nil
 }

--- a/internal/generator/primary.go
+++ b/internal/generator/primary.go
@@ -42,6 +42,7 @@ func (g *Generator) generatePostgreSQLConfig(primaryDir string, postgresqlConfTm
 		"MaxReplicationSlots": len(g.config.Replicas) + 2,
 		"WalKeepSize":         g.config.Options.WalKeepSize,
 		"Port":                g.config.Primary.Port,
+		"HasMonitoring":       g.config.Monitoring.Datadog.Enabled,
 	}
 	outputFile := filepath.Join(primaryDir, "postgresql.conf.custom")
 	return executeTemplateToFile(postgresqlConfTmpl, data, outputFile, "postgres.conf")

--- a/internal/generator/templates/datadog-conf.yaml.tmpl
+++ b/internal/generator/templates/datadog-conf.yaml.tmpl
@@ -1,0 +1,14 @@
+init_config:
+
+instances:
+  - host: {{ .Host }}
+    port:  {{ .Port }}
+    username: {{ .DbUser }}
+    password: {{ .DbPassword }}
+    dbname: {{ .DbName }}
+    ssl: false
+logs:
+  - type: file
+    path: {{ .Datadirectory }}/archive/logs
+    source: postgresql
+    service: postgres

--- a/internal/generator/templates/datadog-install.sh.tmpl
+++ b/internal/generator/templates/datadog-install.sh.tmpl
@@ -1,0 +1,3 @@
+DD_API_KEY= {{ .DataDogApiKey }}
+DD_SITE= {{ .DataDogSite }}
+bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"

--- a/internal/generator/templates/datadog.sql.tmpl
+++ b/internal/generator/templates/datadog.sql.tmpl
@@ -1,0 +1,3 @@
+create user datadog with password {{ .Password }};
+grant pg_monitor to datadog;
+grant SELECT ON pg_stat_database to datadog;

--- a/internal/generator/templates/postgresql.tmpl
+++ b/internal/generator/templates/postgresql.tmpl
@@ -33,3 +33,15 @@ log_line_prefix = '%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h '
 max_connections = 100
 shared_buffers = 256MB
 effective_cache_size = 1GB
+{{- if .HasMonitoring}}
+logging_collector = on
+log_directory = 'pg_log'  
+log_filename = 'pg.log'   
+log_statement = 'all'     
+#log_duration = on
+log_line_prefix= '%m [%p] %d %a %u %h %c '
+log_file_mode = 0644
+log_min_duration_statement = 0    
+log_statement = 'all'
+log_duration = on
+{{- end }}


### PR DESCRIPTION
## Checklist

- [ ] My PR title matches issue title (type(scope): description)
- [ ] I've tested it locally and nothing breaks
- [ ] My code follows the project's coding and workflow standards
- [ ] If my change requires documentation updates, the documentation has been updated to reflect the new feature
- [ ] If my change closes an issue, I've linked the issue under the "Related Issues" section

---

## Summary

<!-- Describe your changes -->

## Related Issues
closes #35 
<!-- Link any Issue IDs (#) -->

## Additional Context

<!-- Add any other context or screenshots -->

## Summary by Sourcery

Add support for generating Datadog monitoring initialization scripts and configuration files when enabled in the project configuration

New Features:
- Generate Datadog install script, SQL setup file, and YAML config from templates when monitoring is enabled
- Inject a HasMonitoring flag into the PostgreSQL configuration to toggle monitoring-related settings