### PR TITLE
feat(devenv/aws/datadog): create initialization scripts

### DIFF
--- a/devenv/aws/generate/templates/deploy-to-servers.sh.tmpl
+++ b/devenv/aws/generate/templates/deploy-to-servers.sh.tmpl
@@ -8,6 +8,7 @@ set -e  # Exit on any error
 SSH_KEY_PATH={{.SSHKeyPath}}
 SSH_USER={{.SSHUser}}
 GENERATED_DIR="./generated"
+ROOT_GENERATED_DIR="../../generated"
 
 # Colors for output
 RED='\033[0;31m'
@@ -48,9 +49,11 @@ test_ssh_connection $PRIMARY_HOST
 
 log_info "Copying 01-setup-primary.sql to $PRIMARY_HOST:/home/ec2-user/"
 scp -i $SSH_KEY_PATH $GENERATED_DIR/01-setup-primary.sql $SSH_USER@$PRIMARY_HOST:/home/ec2-user/
+scp -i $SSH_KEY_PATH $ROOT_GENERATED_DIR/datadog/datadog.sql $SSH_USER@$PRIMARY_HOST:/home/ec2-user/
 
 log_info "Running setup on $PRIMARY_HOST"
 ssh -i $SSH_KEY_PATH $SSH_USER@$PRIMARY_HOST "sudo mv /home/ec2-user/01-setup-primary.sql /var/lib/pgsql/ && sudo -u postgres psql -d postgres -f /var/lib/pgsql/01-setup-primary.sql"
+ssh -i $SSH_KEY_PATH $SSH_USER@$PRIMARY_HOST "sudo mv /home/ec2-user/datadog.sql /var/lib/pgsql/ && sudo -u postgres psql -d postgres -f /var/lib/pgsql/datadog.sql"
 
 # Deploy SQL scripts to replicas
 {{range $i, $replica := .Replicas}}
@@ -61,8 +64,10 @@ test_ssh_connection $REPLICA_HOST
 
 log_info "Copying $REPLICA_SQL to $REPLICA_HOST:/home/ec2-user/"
 scp -i $SSH_KEY_PATH $GENERATED_DIR/$REPLICA_SQL $SSH_USER@$REPLICA_HOST:/home/ec2-user/
+scp -i $SSH_KEY_PATH $ROOT_GENERATED_DIR/datadog/datadog.sql $SSH_USER@$REPLICA_HOST:/home/ec2-user/
 
 log_info "Running setup on $REPLICA_HOST"
 ssh -i $SSH_KEY_PATH $SSH_USER@$REPLICA_HOST "sudo mv /home/ec2-user/$REPLICA_SQL /var/lib/pgsql/ && sudo -u postgres psql -d postgres -f /var/lib/pgsql/$REPLICA_SQL"
+ssh -i $SSH_KEY_PATH $SSH_USER@$REPLICA_HOST "sudo mv /home/ec2-user/datadog.sql /var/lib/pgsql/ && sudo -u postgres psql -d postgres -f /var/lib/pgsql/datadog.sql"
 {{end}}
 

--- a/internal/generator/datadog.go
+++ b/internal/generator/datadog.go
@@ -1,5 +1,3 @@
-
-
 package generator
 
 import (
@@ -7,45 +5,44 @@ import (
 	"text/template"
 )
 
-
 func (g *Generator) generateDatadogFiles(installTmpl, sqlTmpl, confTmpl *template.Template) error {
-   ddDir := filepath.Join(g.outputDir, "datadog")
-   specs := []FileSpec{
-	   {
-		   Tmpl:     installTmpl,
-		   Dir:      ddDir,
-		   Filename: "datadog-install.sh",
-		   Data: map[string]interface{}{
-			   "DataDogApiKey": g.config.Monitoring.Datadog.ApiKey,
-			   "DataDogSite":   g.config.Monitoring.Datadog.Site,
-		   },
-	   },
-	   {
-		   Tmpl:     sqlTmpl,
-		   Dir:      ddDir,
-		   Filename: "datadog.sql",
-		   Data: map[string]interface{}{
-			   "Password": g.config.Primary.DbPassword,
-		   },
-	   },
-	   {
-		   Tmpl:     confTmpl,
-		   Dir:      ddDir,
-		   Filename: "datadog-conf.yaml",
-		   Data: map[string]interface{}{
-			   "Host":          g.config.Primary.Host,
-			   "Port":          g.config.Primary.Port,
-			   "DbName":        g.config.Primary.DbName,
-			   "DbUser":        g.config.Primary.DbUser,
-			   "DbPassword":    g.config.Primary.DbPassword,
-			   "Datadirectory": g.config.Primary.DataDirectory,
-		   },
-	   },
-   }
-   for _, spec := range specs {
-	   if err := g.renderTemplate(spec.Tmpl, spec.Dir, spec.Filename, spec.Data); err != nil {
-		   return err
-	   }
-   }
-   return nil
+	ddDir := filepath.Join(g.outputDir, "datadog")
+	specs := []FileSpec{
+		{
+			Tmpl:     installTmpl,
+			Dir:      ddDir,
+			Filename: "datadog-install.sh",
+			Data: map[string]interface{}{
+				"DataDogApiKey": g.config.Monitoring.Datadog.ApiKey,
+				"DataDogSite":   g.config.Monitoring.Datadog.Site,
+			},
+		},
+		{
+			Tmpl:     sqlTmpl,
+			Dir:      ddDir,
+			Filename: "datadog.sql",
+			Data: map[string]interface{}{
+				"Password": g.config.Primary.DbPassword,
+			},
+		},
+		{
+			Tmpl:     confTmpl,
+			Dir:      ddDir,
+			Filename: "datadog-conf.yaml",
+			Data: map[string]interface{}{
+				"Host":          g.config.Primary.Host,
+				"Port":          g.config.Primary.Port,
+				"DbName":        g.config.Primary.DbName,
+				"DbUser":        g.config.Primary.DbUser,
+				"DbPassword":    g.config.Primary.DbPassword,
+				"Datadirectory": g.config.Primary.DataDirectory,
+			},
+		},
+	}
+	for _, spec := range specs {
+		if err := g.renderTemplate(spec.Tmpl, spec.Dir, spec.Filename, spec.Data); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/generator/primary.go
+++ b/internal/generator/primary.go
@@ -1,4 +1,3 @@
-
 package generator
 
 import (
@@ -6,55 +5,54 @@ import (
 	"text/template"
 )
 
-
 // generatePrimaryFiles creates configuration files for the primary PostgreSQL server
 func (g *Generator) generatePrimaryFiles(pgHbaTmpl, postgresqlConfTmpl, setupPrimaryTmpl *template.Template) error {
-   primaryDir := filepath.Join(g.outputDir, "primary")
-   specs := []FileSpec{
-	   {
-		   Tmpl:     postgresqlConfTmpl,
-		   Dir:      primaryDir,
-		   Filename: "postgresql.conf.custom",
-		   Data: map[string]interface{}{
-			   "WalLevel":            g.config.Options.WalLevel,
-			   "HotStandby":          g.config.Options.HotStandby,
-			   "SynchronousCommit":   g.config.Options.SynchronousCommit,
-			   "MaxWalSenders":       g.config.Options.MaxWalSenders,
-			   "MaxReplicationSlots": len(g.config.Replicas) + 2,
-			   "WalKeepSize":         g.config.Options.WalKeepSize,
-			   "Port":                g.config.Primary.Port,
-			   "HasMonitoring":       g.config.Monitoring.Datadog.Enabled,
-		   },
-	   },
-	   {
-		   Tmpl:     pgHbaTmpl,
-		   Dir:      primaryDir,
-		   Filename: "pg_hba.conf.custom",
-		   Data: map[string]interface{}{
-			   "ReplicationUser": g.config.Primary.ReplicationUser,
-			   "Replicas":        g.config.Replicas,
-		   },
-	   },
-	   {
-		   Tmpl:     setupPrimaryTmpl,
-		   Dir:      primaryDir,
-		   Filename: "setup_primary.sh",
-		   Data: map[string]interface{}{
-			   "PrimaryHost":         g.config.Primary.Host,
-			   "PrimaryPort":         g.config.Primary.Port,
-			   "DbUser":              g.config.Primary.DbUser,
-			   "DbName":              g.config.Primary.DbName,
-			   "ReplicationUser":     g.config.Primary.ReplicationUser,
-			   "ReplicationPassword": g.config.Primary.ReplicationPassword,
-			   "Replicas":            g.config.Replicas,
-			   "DataDirectory":       g.config.Primary.DataDirectory,
-		   },
-	   },
-   }
-   for _, spec := range specs {
-	   if err := g.renderTemplate(spec.Tmpl, spec.Dir, spec.Filename, spec.Data); err != nil {
-		   return err
-	   }
-   }
-   return nil
+	primaryDir := filepath.Join(g.outputDir, "primary")
+	specs := []FileSpec{
+		{
+			Tmpl:     postgresqlConfTmpl,
+			Dir:      primaryDir,
+			Filename: "postgresql.conf.custom",
+			Data: map[string]interface{}{
+				"WalLevel":            g.config.Options.WalLevel,
+				"HotStandby":          g.config.Options.HotStandby,
+				"SynchronousCommit":   g.config.Options.SynchronousCommit,
+				"MaxWalSenders":       g.config.Options.MaxWalSenders,
+				"MaxReplicationSlots": len(g.config.Replicas) + 2,
+				"WalKeepSize":         g.config.Options.WalKeepSize,
+				"Port":                g.config.Primary.Port,
+				"HasMonitoring":       g.config.Monitoring.Datadog.Enabled,
+			},
+		},
+		{
+			Tmpl:     pgHbaTmpl,
+			Dir:      primaryDir,
+			Filename: "pg_hba.conf.custom",
+			Data: map[string]interface{}{
+				"ReplicationUser": g.config.Primary.ReplicationUser,
+				"Replicas":        g.config.Replicas,
+			},
+		},
+		{
+			Tmpl:     setupPrimaryTmpl,
+			Dir:      primaryDir,
+			Filename: "setup_primary.sh",
+			Data: map[string]interface{}{
+				"PrimaryHost":         g.config.Primary.Host,
+				"PrimaryPort":         g.config.Primary.Port,
+				"DbUser":              g.config.Primary.DbUser,
+				"DbName":              g.config.Primary.DbName,
+				"ReplicationUser":     g.config.Primary.ReplicationUser,
+				"ReplicationPassword": g.config.Primary.ReplicationPassword,
+				"Replicas":            g.config.Replicas,
+				"DataDirectory":       g.config.Primary.DataDirectory,
+			},
+		},
+	}
+	for _, spec := range specs {
+		if err := g.renderTemplate(spec.Tmpl, spec.Dir, spec.Filename, spec.Data); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/generator/templates/datadog.sql.tmpl
+++ b/internal/generator/templates/datadog.sql.tmpl
@@ -1,3 +1,3 @@
-create user datadog with password {{ .Password }};
+create user datadog with password '{{ .Password }}';
 grant pg_monitor to datadog;
 grant SELECT ON pg_stat_database to datadog;


### PR DESCRIPTION
## Checklist

- [x] My PR title matches issue title (type(scope): description)
- [x] I've tested it locally and nothing breaks
- [x] My code follows the project's coding and workflow standards
- [x] If my change requires documentation updates, the documentation has been updated to reflect the new feature
- [x] If my change closes an issue, I've linked the issue under the "Related Issues" section

---

## Summary

## Related Issues
Closes #36

## Additional Context

<!-- Add any other context or screenshots -->

## Summary by Sourcery

Add support for generating DataDog initialization scripts and integrate them into the AWS VM deployment process

New Features:
- Generate DataDog install, SQL, and configuration files via the internal generator

Enhancements:
- Include DataDog files in the VM file transfer lists for both primary and replica servers
- Remove debug logging and unused pretty-printing in the AWS SSH script generator